### PR TITLE
Decoding firefox Login info with utf8 encoding

### DIFF
--- a/Firefox.cs
+++ b/Firefox.cs
@@ -294,7 +294,9 @@ namespace KeePassBrowserImporter
 
 				try
 				{
-					result = Marshal.PtrToStringAnsi(reply.Data, reply.Length);
+					byte[] tmp = new byte[reply.Length];
+					Marshal.Copy(reply.Data, tmp, 0, reply.Length);
+					result = System.Text.Encoding.UTF8.GetString(tmp);
 				}
 				finally
 				{


### PR DESCRIPTION
Firefox uses UTF8 for login info storage. Since utf8 can decode ASCII characters(without extended codes) properly, the decoding method was changed to UTF8 for compatibility.
I have test it with my own Firefox profile which contains both English and Chinese usernames and it works just well.
